### PR TITLE
Release 2.11.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ the gematik central-IDP with the gematik Authenticator application.
 Allows a user to log in with his HBA (Heil-Berufs-Ausweis) card, supplying HBA and SMCB (Elektronischer
 Praxis-/Institutionsausweis) card information. Additionally, HBA- and SMCB-specific IDP mappers are provided.
 
-Please be aware, that this plugin was developed for and tested with Keycloak 22 Quarkus. With version 22, Keycloak
+Please be aware, that this plugin was developed for and tested with Keycloak 24 Quarkus. With version 22, Keycloak
 moved from JavaX to Jakarta, which is why this version is incompatible with other versions of Keycloak.
 
 ## Installation
@@ -21,6 +21,8 @@ moved from JavaX to Jakarta, which is why this version is incompatible with othe
    Specific configuration properties are listed below.
 4. Set the login theme in your realm, where you added the Identity Provider, to gematik-idp for the full support of
    all features. You can also add the content from `./themes/gematik-idp` to you custom theme if necessary.
+    - By default the theme-resources are included in the jar. If you have your own theme, you can exclude the
+      theme-resources with specifying the maven profile `excludeThemeResources`.
 
 ## Local Deployment
 
@@ -66,10 +68,12 @@ in the Keycloak-Github:
 
 ## Theme
 
-The template and javascript files are supplied as part of the compiled jar and are available under 
-`/src/main/resources/theme-resources`. To use the script it has to be added to the `theme.properties` file as scripts: 
-`scripts=js/gematik-idp.js`. Sample theme configuration can be found under `/themes/gematik-idp`. For more information 
-about extending your own themes please read the [Deploying Themes](https://www.keycloak.org/docs/latest/server_development/index.html#deploying-themes) section in the Keycloak documentation.
+The template and javascript files are supplied as part of the compiled jar and are available under
+`/src/main/resources/theme-resources`. To use the script it has to be added to the `theme.properties` file as scripts:
+`scripts=js/gematik-idp.js`. Sample theme configuration can be found under `/themes/gematik-idp`. For more information
+about extending your own themes please read
+the [Deploying Themes](https://www.keycloak.org/docs/latest/server_development/index.html#deploying-themes) section in
+the Keycloak documentation.
 
 Please make sure to use your standard browser without an incognito window, when using the `authenticator://`
 Authenticator Url

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,12 +45,12 @@ services:
       JAVA_OPTS: -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
     volumes:
       - ./sample-realm:/opt/keycloak/data/import/
-      - ./target/gematik-idp-2.9.0.jar:/opt/keycloak/providers/gematik-idp-2.9.0.jar
+      - ./target/gematik-idp-2.11.0.jar:/opt/keycloak/providers/gematik-idp-2.11.0.jar
       - ./themes/gematik-idp:/opt/keycloak/themes/gematik-idp
     entrypoint: "/opt/keycloak/bin/kc.sh start-dev --import-realm"
 
   idp-server:
-    image: gematik1/idp-server:27.0.3
+    image: gematik1/idp-server:28.0.1
     container_name: gem-ref-idp-server
     restart: always
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>de.bdr.servko</groupId>
     <artifactId>gematik-idp</artifactId>
-    <version>2.9.0</version>
+    <version>2.11.0</version>
     <description>
         Keycloak plugin allowing authentication with the gematik Authenticator and central IDP.
     </description>
@@ -33,25 +33,25 @@
 
         <!-- Maven Plugin Versions -->
         <java.version>17</java.version>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
-        <dependency-check-maven.version>9.2.0</dependency-check-maven.version>
+        <dependency-check-maven.version>10.0.2</dependency-check-maven.version>
         <jacoco-maven.version>0.8.11</jacoco-maven.version>
         <resteasy-reactive.version>3.2.10.Final</resteasy-reactive.version>
 
         <!-- Misc Plugin Versions -->
-        <kotlin.version>1.9.24</kotlin.version>
+        <kotlin.version>2.0.0</kotlin.version>
         <jose4j.version>0.9.6</jose4j.version>
         <snakeyaml.version>2.2</snakeyaml.version>
 
         <!-- Test Plugin Versions -->
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
-        <junit5-plugin.version>5.10.2</junit5-plugin.version>
+        <junit5-plugin.version>5.10.3</junit5-plugin.version>
         <mockito-plugin.version>5.2.0</mockito-plugin.version>
         <mockito-kotlin.version>5.3.1</mockito-kotlin.version>
-        <assertj-plugin.version>3.25.3</assertj-plugin.version>
+        <assertj-plugin.version>3.26.0</assertj-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
 
         <!-- Sonar Properties -->
@@ -322,6 +322,21 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>excludeThemeResources</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>${project.basedir}/src/main/resources</directory>
+                        <excludes>
+                            <exclude>**/theme-resources/**</exclude>
+                        </excludes>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+
         <profile>
             <id>dependency-check</id>
             <build>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## Release 2.11.0
+
+* Fixed an issue, where a wrongly configured Gematik-IDP url causes an error in Keycloak, which prevented the loading of
+  the Gematik-IDP configuration page
+* Improved nullability handling of `authenticationSession.getAuthNote(...)` method results
+* Add maven profile to exclude theme-resources
+
+## Release 2.10.0
+
+* Update Kotlin to v2.0.0
+* Dependency updates
+
 ## Release 2.9.0
 
 * Update to Keycloak 24.0.5

--- a/src/main/kotlin/de/bdr/servko/keycloak/gematik/idp/rest/GematikIDPResource.kt
+++ b/src/main/kotlin/de/bdr/servko/keycloak/gematik/idp/rest/GematikIDPResource.kt
@@ -213,7 +213,7 @@ abstract class GematikIDPResource {
         errorDetails: String?,
         errorUri: String?,
     ): Response {
-        logger.error("Authenticator returned error: $error | error-details: $errorDetails | error-uri $errorUri")
+        logger.warn("Authenticator returned error: $error | error-details: $errorDetails | error-uri $errorUri")
         return forms.setError(AuthenticatorErrorTypes.valueOf(error).error, errorDetails ?: "Unknown")
             .createErrorPage(Response.Status.BAD_REQUEST)
     }
@@ -235,7 +235,6 @@ abstract class GematikIDPResource {
     }
 
     fun handleSessionTimeout(e: SessionNotFoundException): Response {
-        logger.error(e.message)
         return forms.setError(AuthenticatorErrorTypes.LOGIN_TIMEOUT.error, e.message)
             .createErrorPage(Response.Status.BAD_REQUEST)
     }

--- a/src/main/kotlin/de/bdr/servko/keycloak/gematik/idp/rest/GematikIdpCardTypeBasedResource.kt
+++ b/src/main/kotlin/de/bdr/servko/keycloak/gematik/idp/rest/GematikIdpCardTypeBasedResource.kt
@@ -110,9 +110,9 @@ abstract class GematikIdpCardTypeBasedResource: GematikIDPResource() {
 
         return when (val step = GematikIDPUtil.getGematikIdpStepFrom(authSession)) {
             GematikIDPStep.ERROR -> {
-                val error = authSession.getAuthNote(GematikIdpLiterals.ERROR)
-                val errorDetails = authSession.getAuthNote(GematikIdpLiterals.ERROR_DETAILS)
-                val errorUri = authSession.getAuthNote(GematikIdpLiterals.ERROR_URI)
+                val error: String? = authSession.getAuthNote(GematikIdpLiterals.ERROR)
+                val errorDetails: String? = authSession.getAuthNote(GematikIdpLiterals.ERROR_DETAILS)
+                val errorUri: String? = authSession.getAuthNote(GematikIdpLiterals.ERROR_URI)
 
                 handleErrorWhenCalledFromBrowser(error, errorDetails, errorUri)
             }
@@ -150,7 +150,7 @@ abstract class GematikIdpCardTypeBasedResource: GematikIDPResource() {
         val version = VersionFromUserAgentReader.readVersionFrom(userAgent)
         GematikIDPUtil.addAuthenticatorVersionToMdc(version)
 
-        if (code == null && encodedState == null) {
+        if (code.isNullOrEmpty() && encodedState.isNullOrEmpty()) {
             return handleErrorWhenCalledFromBrowser(error, errorDetails, errorUri)
         }
 
@@ -231,7 +231,8 @@ abstract class GematikIdpCardTypeBasedResource: GematikIDPResource() {
         code: String,
         cardType: String,
     ): MutableMap<String, Any>? {
-        val codeVerifier = authSession.getAuthNote(GematikIdpLiterals.CODE_VERIFIER)
+        val codeVerifier: String = authSession.getAuthNote(GematikIdpLiterals.CODE_VERIFIER)
+            ?: return null
         val idToken = certificateService.fetchIdToken(codeVerifier, code)
 
         val claimsMap = idToken.jwtClaims.claimsMap

--- a/src/main/kotlin/de/bdr/servko/keycloak/gematik/idp/service/GematikIDPService.kt
+++ b/src/main/kotlin/de/bdr/servko/keycloak/gematik/idp/service/GematikIDPService.kt
@@ -57,7 +57,7 @@ open class GematikIDPService(private val session: KeycloakSession) {
 
     private fun authSessionNotFound(encodedState: String?): SessionNotFoundException {
         val realm = session.context.realm
-        logger.error("AuthenticationSessionModel not found for state $encodedState and realm ${realm.name}")
+        logger.warn("AuthenticationSessionModel not found for state $encodedState and realm ${realm.name}")
         return SessionNotFoundException("AuthenticationSessionModel not found for state $encodedState")
     }
 }

--- a/src/main/kotlin/de/bdr/servko/keycloak/gematik/idp/util/GematikIDPUtil.kt
+++ b/src/main/kotlin/de/bdr/servko/keycloak/gematik/idp/util/GematikIDPUtil.kt
@@ -37,26 +37,25 @@ import java.net.URI
 
 class GematikIDPUtil {
     companion object {
-        fun getGematikIdpStepFrom(authSession: AuthenticationSessionModel): GematikIDPStep {
-            return authSession.getAuthNote(GematikIdpLiterals.GEMATIK_IDP_STEP).let {
+        fun getGematikIdpStepFrom(authSession: AuthenticationSessionModel): GematikIDPStep =
+            authSession.getAuthNote(GematikIdpLiterals.GEMATIK_IDP_STEP)?.let {
                 GematikIDPStep.valueOf(it)
-            }
-        }
+            } ?: GematikIDPStep.ERROR
 
         fun getCertificateDataFromAuthNote(
             authSession: AuthenticationSessionModel,
             authNote: String,
-        ): Map<String, Any>? {
-            //we set the IDP DATA as claims map, so we know the types
-            val note = authSession.getAuthNote(authNote)
-            @Suppress("UNCHECKED_CAST")
-            return if (note != null)
-                JsonSerialization.readValue(note, Map::class.java) as Map<String, Any>
-            else
-                null
-        }
+        ): Map<String, Any>? =
+            authSession.getAuthNote(authNote)?.let {
+                //we set the IDP DATA as claims map, so we know the types
+                @Suppress("UNCHECKED_CAST")
+                JsonSerialization.readValue(it, Map::class.java) as Map<String, Any>?
+            }
 
-        fun setAuthenticatorVersionInAuthSession(version: AuthenticatorVersion, authSession: AuthenticationSessionModel) {
+        fun setAuthenticatorVersionInAuthSession(
+            version: AuthenticatorVersion,
+            authSession: AuthenticationSessionModel,
+        ) {
             if (!version.isNullOrEmpty()) {
                 authSession.setAuthNote(GematikIdpLiterals.AUTHENTICATOR_VERSION, version.toString())
             }
@@ -97,7 +96,7 @@ class GematikIDPUtil {
             hbaData: Map<String, Any>? = null,
             smcbData: Map<String, Any>? = null,
         ) {
-            ContextData.values().forEach { ctx ->
+            ContextData.entries.forEach { ctx ->
                 contextData[ctx.name] = when (ctx.cardType) {
                     CardType.HBA -> hbaData?.get(ctx.claim.value) ?: "UNKNOWN"
                     CardType.SMCB -> smcbData?.get(ctx.claim.value) ?: "UNKNOWN"

--- a/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/GematikIDPTest.kt
+++ b/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/GematikIDPTest.kt
@@ -30,7 +30,10 @@ import org.keycloak.broker.provider.IdentityProvider
 import org.keycloak.broker.provider.util.IdentityBrokerState
 import org.keycloak.events.EventBuilder
 import org.keycloak.forms.login.LoginFormsProvider
-import org.keycloak.models.*
+import org.keycloak.models.KeycloakContext
+import org.keycloak.models.KeycloakSession
+import org.keycloak.models.KeycloakUriInfo
+import org.keycloak.models.RealmModel
 import org.keycloak.sessions.AuthenticationSessionModel
 import org.keycloak.sessions.AuthenticationSessionProvider
 import org.keycloak.sessions.RootAuthenticationSessionModel
@@ -54,13 +57,9 @@ internal class GematikIDPTest {
     private val realm = mock<RealmModel> {
         on { name } doReturn realmName
     }
-    private val clientMock = mock<ClientModel> {
-        on { isEnabled } doReturn true
-    }
 
     private val rootAuthSessionMock: RootAuthenticationSessionModel = mock<RootAuthenticationSessionModel> {
         on { id } doReturn rootSessionId
-        on { getAuthenticationSession(clientMock, tabId) } doReturn authSession
     }
     private val authSession = mock<AuthenticationSessionModel> {
         on { realm } doReturn realm

--- a/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/mapper/HbaConsentAttributeMapperTest.kt
+++ b/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/mapper/HbaConsentAttributeMapperTest.kt
@@ -34,6 +34,8 @@ internal class HbaConsentAttributeMapperTest {
     private val realm: RealmModel = mock()
 
     private val context  = spy(BrokeredIdentityContext("id"))
+    private val consentCreatedDateAttribute = AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_CREATED_DATE_ATTRIBUTE
+    private val consentLastUpdatedDateAttribute = AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_LAST_UPDATED_DATE_ATTRIBUTE
     private val mapperModel = IdentityProviderMapperModel().apply {
         config = mapOf(
             AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_CREATED_DATE_ATTRIBUTE to
@@ -43,8 +45,6 @@ internal class HbaConsentAttributeMapperTest {
         )
     }
 
-    private val consentCreatedDateAttribute = AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_CREATED_DATE_ATTRIBUTE
-    private val consentLastUpdatedDateAttribute = AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_LAST_UPDATED_DATE_ATTRIBUTE
     private val createdDateAttribute = AuthenticatorClaim.HBA_CONSENT_CREATED_DATE.scope
     private val lastUpdatedDateAttribute = AuthenticatorClaim.HBA_CONSENT_LAST_UPDATED_DATE.scope
 

--- a/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/mapper/SmcbConsentAttributeMapperTest.kt
+++ b/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/mapper/SmcbConsentAttributeMapperTest.kt
@@ -34,6 +34,8 @@ internal class SmcbConsentAttributeMapperTest {
     private val realm: RealmModel = mock()
 
     private val context  = spy(BrokeredIdentityContext("id"))
+    private val consentCreatedDateAttribute = AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_CREATED_DATE_ATTRIBUTE
+    private val consentLastUpdatedDateAttribute = AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_LAST_UPDATED_DATE_ATTRIBUTE
     private val mapperModel = IdentityProviderMapperModel().apply {
         config = mapOf(
             AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_CREATED_DATE_ATTRIBUTE to
@@ -43,8 +45,6 @@ internal class SmcbConsentAttributeMapperTest {
         )
     }
 
-    private val consentCreatedDateAttribute = AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_CREATED_DATE_ATTRIBUTE
-    private val consentLastUpdatedDateAttribute = AbstractGematikAuthenticatorConsentAttributeMapper.CONFIG_AUTHENTICATOR_LAST_UPDATED_DATE_ATTRIBUTE
     private val createdDateAttribute = AuthenticatorClaim.SMCB_CONSENT_CREATED_DATE.scope
     private val lastUpdatedDateAttribute = AuthenticatorClaim.SMCB_CONSENT_LAST_UPDATED_DATE.scope
 

--- a/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/rest/GematikIDPMultiResourceTest.kt
+++ b/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/rest/GematikIDPMultiResourceTest.kt
@@ -67,8 +67,8 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
         BrainpoolCurves.init()
         whenever(sessionMock.authenticationSessions()).thenReturn(authenticationSession)
         whenever(authenticationSession.getRootAuthenticationSession(realmMock, ROOT_SESSION_ID)).thenReturn(
-                rootAuthenticationSession
-            )
+            rootAuthenticationSession
+        )
     }
 
     @Test
@@ -81,6 +81,13 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
         assertThat(clientBean.clientId).isEqualTo(CLIENT_ID)
 
         verify(formsMock).createForm("gematik-idp-timeout.ftl")
+    }
+
+    @Test
+    fun `timeout - resolveAuthSession not found`() {
+        testResolveAuthSessionNotFoundFailure {
+            underTest.timeout(state)
+        }
     }
 
     @Test
@@ -155,6 +162,20 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
     }
 
     @Test
+    fun `status - resolveAuthSession not found`() {
+        testResolveAuthSessionNotFoundStatusEndpointFailure {
+            underTest.status(state)
+        }
+    }
+
+    @Test
+    fun `status - resolveAuthSession fails`() {
+        testResolveAuthSessionFailure {
+            underTest.status(state)
+        }
+    }
+
+    @Test
     fun `nextStep - idp error saved in auth session`() {
         // arrange
         val error = "invalid_scope"
@@ -162,7 +183,8 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
         val errorUri = "https://wiki.gematik.de/pages/viewpage.action?pageId=466488828"
 
         whenever(formsMock.createErrorPage(Response.Status.BAD_REQUEST)).thenReturn(
-            Response.status(Response.Status.BAD_REQUEST).build())
+            Response.status(Response.Status.BAD_REQUEST).build()
+        )
 
         whenever(authSessionMock.getAuthNote("error")).thenReturn(error)
         whenever(authSessionMock.getAuthNote("error_details")).thenReturn(errorDetails)
@@ -192,7 +214,8 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
         val error = "Authentication is still in progress. Current step is $step. Please try again later."
 
         whenever(formsMock.createErrorPage(Response.Status.PRECONDITION_REQUIRED)).thenReturn(
-            Response.status(Response.Status.PRECONDITION_REQUIRED).build())
+            Response.status(Response.Status.PRECONDITION_REQUIRED).build()
+        )
 
         whenever(authSessionMock.getAuthNote("GEMATIK_IDP_STEP"))
             .thenReturn(step.name)
@@ -220,7 +243,8 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
         whenever(callbackMock.authenticated(any())).thenReturn(Response.ok().build())
 
         whenever(formsMock.createErrorPage(Response.Status.BAD_REQUEST)).thenReturn(
-            Response.status(Response.Status.BAD_REQUEST).build())
+            Response.status(Response.Status.BAD_REQUEST).build()
+        )
 
         // act
         val result = underTest.nextStep(state)
@@ -271,7 +295,28 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
     }
 
     @Test
-    fun `result resolveAuthSession fails`() {
+    fun `nextStep - resolveAuthSession not found`() {
+        testResolveAuthSessionNotFoundFailure {
+            underTest.nextStep(state)
+        }
+    }
+
+    @Test
+    fun `nextStep - resolveAuthSession fails`() {
+        testResolveAuthSessionFailure {
+            underTest.nextStep(state)
+        }
+    }
+
+    @Test
+    fun `result - resolveAuthSession not found`() {
+        testResolveAuthSessionNotFoundFailure {
+            underTest.result("", state)
+        }
+    }
+
+    @Test
+    fun `result - resolveAuthSession fails`() {
         testResolveAuthSessionFailure {
             underTest.result("", state)
         }
@@ -315,7 +360,7 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
 
     @Test
     fun `result - no auth session found - error callback`() {
-        testResolveAuthSessionFailure {
+        testResolveAuthSessionNotFoundFailure {
             underTest.result(CODE, state)
         }
     }
@@ -355,6 +400,14 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
         verify(authSessionMock).setAuthNote("error_details", errorDetails)
         verify(authSessionMock).setAuthNote("error_uri", errorUri)
         verify(authSessionMock).setAuthNote("GEMATIK_IDP_STEP", GematikIDPStep.ERROR.name)
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    fun `result - no or empty code and state - corresponding error is set`(code: String?) {
+        testAssertCodeAndStateNullOrEmpty {
+            underTest.result(code, code)
+        }
     }
 
     @Test
@@ -397,7 +450,8 @@ internal class GematikIDPMultiResourceTest : GematikIDPEndpointBaseTest() {
         mockDoPostToGetSmcbToken()
 
         // act
-        val result = underTest.result(CODE,
+        val result = underTest.result(
+            CODE,
             state,
             "SMC-B",
             null,

--- a/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/rest/GematikIDPSmcbResourceTest.kt
+++ b/src/test/kotlin/de/bdr/servko/keycloak/gematik/idp/rest/GematikIDPSmcbResourceTest.kt
@@ -87,6 +87,13 @@ internal class GematikIDPSmcbResourceTest : GematikIDPEndpointBaseTest() {
     }
 
     @Test
+    fun `timeout - resolveAuthSession not found`() {
+        testResolveAuthSessionNotFoundFailure {
+            underTest.timeout(state)
+        }
+    }
+
+    @Test
     fun `timeout - resolveAuthSession fails`() {
         testResolveAuthSessionFailure {
             underTest.timeout(state)
@@ -155,6 +162,20 @@ internal class GematikIDPSmcbResourceTest : GematikIDPEndpointBaseTest() {
         assertThat(result.statusInfo).isEqualTo(Response.Status.OK)
         assertThat((result.entity as GematikIDPStatusResponse).currentStep).isEqualTo(step.name)
         assertNextStepUrl((result.entity as GematikIDPStatusResponse).nextStepUrl!!)
+    }
+
+    @Test
+    fun `status - resolveAuthSession not found`() {
+        testResolveAuthSessionNotFoundStatusEndpointFailure {
+            underTest.status(state)
+        }
+    }
+
+    @Test
+    fun `status - resolveAuthSession fails`() {
+        testResolveAuthSessionFailure {
+            underTest.status(state)
+        }
     }
 
     @Test
@@ -274,7 +295,28 @@ internal class GematikIDPSmcbResourceTest : GematikIDPEndpointBaseTest() {
     }
 
     @Test
-    fun `result resolveAuthSession fails`() {
+    fun `nextStep - resolveAuthSession not found`() {
+        testResolveAuthSessionNotFoundFailure {
+            underTest.nextStep(state)
+        }
+    }
+
+    @Test
+    fun `nextStep - resolveAuthSession fails`() {
+        testResolveAuthSessionFailure {
+            underTest.nextStep(state)
+        }
+    }
+
+    @Test
+    fun `result resolveAuthSession not found`() {
+        testResolveAuthSessionNotFoundFailure {
+            underTest.result("", state)
+        }
+    }
+
+    @Test
+    fun `result - resolveAuthSession fails`() {
         testResolveAuthSessionFailure {
             underTest.result("", state)
         }
@@ -298,6 +340,14 @@ internal class GematikIDPSmcbResourceTest : GematikIDPEndpointBaseTest() {
         verify(authSessionMock).setAuthNote("GEMATIK_IDP_STEP", GematikIDPStep.ERROR.name)
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    fun `result - no or empty code and state - corresponding error is set`(code: String?) {
+        testAssertCodeAndStateNullOrEmpty {
+            underTest.result(code, code)
+        }
+    }
+
     @Test
     fun `result - function call with authenticator consent error`() {
         // arrange
@@ -314,13 +364,6 @@ internal class GematikIDPSmcbResourceTest : GematikIDPEndpointBaseTest() {
             .setAuthNote("error_details", "User declined consent. Please start again and give your consent.")
         verify(authSessionMock).setAuthNote("error_uri", null)
         verify(authSessionMock).setAuthNote("GEMATIK_IDP_STEP", GematikIDPStep.ERROR.name)
-    }
-
-    @Test
-    fun `result - no auth session found - error callback`() {
-        testResolveAuthSessionFailure {
-            underTest.result(CODE, state)
-        }
     }
 
     @Test


### PR DESCRIPTION
## Release 2.11.0

* Fixed an issue, where a wrongly configured Gematik-IDP url causes an error in Keycloak, which prevented the loading of
  the Gematik-IDP configuration page
* Improved nullability handling of `authenticationSession.getAuthNote(...)` method results
* Add maven profile to exclude theme-resources

## Release 2.10.0

* Update Kotlin to v2.0.0
* Dependency updates